### PR TITLE
chore(db-dependency): move max_connections increase to consortia

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -591,8 +591,6 @@ postgresql:
     pgAuditLog: "write, ddl"
     logLinePrefix: "%m %u %d "
   primary:
-    extendedConfiguration: |
-      max_connections = 200
     initdb:
       scriptsConfigMap: "configmap-postgres-init"
     extraEnvVars:
@@ -606,10 +604,6 @@ postgresql:
           secretKeyRef:
             name: "{{ .Values.auth.existingSecret }}"
             key: "provisioning-password"
-  readReplicas:
-    extendedConfiguration: |
-      max_connections = 200
-
 
 externalDatabase:
 # -- External PostgreSQL configuration

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -591,6 +591,8 @@ postgresql:
     pgAuditLog: "write, ddl"
     logLinePrefix: "%m %u %d "
   primary:
+    # -- Extended PostgreSQL Primary configuration (increase of max_connections recommended - default is 100)
+    extendedConfiguration: ""
     initdb:
       scriptsConfigMap: "configmap-postgres-init"
     extraEnvVars:
@@ -604,6 +606,9 @@ postgresql:
           secretKeyRef:
             name: "{{ .Values.auth.existingSecret }}"
             key: "provisioning-password"
+  readReplicas:
+  # -- Extended PostgreSQL read only replicas configuration (increase of max_connections recommended - default is 100)
+    extendedConfiguration: ""
 
 externalDatabase:
 # -- External PostgreSQL configuration

--- a/consortia/environments/values-beta.yaml
+++ b/consortia/environments/values-beta.yaml
@@ -226,3 +226,9 @@ postgresql:
     replicationPassword: "<path:portal/data/beta/postgres#replication-password>"
     portalPassword: "<path:portal/data/beta/postgres#portal-password>"
     provisioningPassword: "<path:portal/data/beta/postgres#provisioning-password>"
+  primary:
+    extendedConfiguration: |
+      max_connections = 200
+  readReplicas:
+    extendedConfiguration: |
+      max_connections = 200

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -226,3 +226,9 @@ postgresql:
     replicationPassword: "<path:portal/data/dev/postgres#replication-password>"
     portalPassword: "<path:portal/data/dev/postgres#portal-password>"
     provisioningPassword: "<path:portal/data/dev/postgres#provisioning-password>"
+  primary:
+    extendedConfiguration: |
+      max_connections = 200
+  readReplicas:
+    extendedConfiguration: |
+      max_connections = 200

--- a/consortia/environments/values-int.yaml
+++ b/consortia/environments/values-int.yaml
@@ -226,3 +226,9 @@ postgresql:
     replicationPassword: "<path:portal/data/int/postgres#replication-password>"
     portalPassword: "<path:portal/data/int/postgres#portal-password>"
     provisioningPassword: "<path:portal/data/int/postgres#provisioning-password>"
+  primary:
+    extendedConfiguration: |
+      max_connections = 200
+  readReplicas:
+    extendedConfiguration: |
+      max_connections = 200

--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -227,3 +227,9 @@ postgresql:
     replicationPassword: "<path:portal/data/pen/postgres#replication-password>"
     portalPassword: "<path:portal/data/pen/postgres#portal-password>"
     provisioningPassword: "<path:portal/data/pen/postgres#provisioning-password>"
+  primary:
+    extendedConfiguration: |
+      max_connections = 200
+  readReplicas:
+    extendedConfiguration: |
+      max_connections = 200

--- a/consortia/environments/values-preprod.yaml
+++ b/consortia/environments/values-preprod.yaml
@@ -226,3 +226,9 @@ postgresql:
     replicationPassword: "<path:portal/data/pre-prod/postgres#replication-password>"
     portalPassword: "<path:portal/data/pre-prod/postgres#portal-password>"
     provisioningPassword: "<path:portal/data/pre-prod/postgres#provisioning-password>"
+  primary:
+    extendedConfiguration: |
+      max_connections = 200
+  readReplicas:
+    extendedConfiguration: |
+      max_connections = 200

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -227,3 +227,9 @@ postgresql:
     replicationPassword: "<path:portal/data/dev/postgres#replication-password>"
     portalPassword: "<path:portal/data/dev/postgres#portal-password>"
     provisioningPassword: "<path:portal/data/dev/postgres#provisioning-password>"
+  primary:
+    extendedConfiguration: |
+      max_connections = 200
+  readReplicas:
+    extendedConfiguration: |
+      max_connections = 200


### PR DESCRIPTION
## Description

move increase of max_connections for db-dependency to consortia environments and add note for max_connections recommendation increase to default values file

## Why

max_connections for db-dependency is to be considered a env specific configuration
also: to be avoid issues at upgrade

## Issue

n/a
ref: CPLP-2739
https://github.com/eclipse-tractusx/portal-cd/pull/19

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
