### PR TITLE
chore(trg-helm): improve helm test workflow

### DIFF
--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -1,6 +1,6 @@
 name: Portal Lint and Test Chart
 
-on:
+on: 
   push:
     paths:
       - 'charts/portal/**'
@@ -47,10 +47,6 @@ jobs:
       # run chart linting 
       - name: Run chart-testing (lint)
         run: ct lint --charts charts/portal --config charts/chart-testing-config.yaml
-
-      # run chart linting 
-      - name: Run kubectl version
-        run: kubectl version
 
       # install the chart to the kind cluster and run helm test
       # define charts to test with the --charts parameter

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Kubernetes KinD Cluster
-        uses: container-tools/kind-action@v1
+        uses: container-tools/kind-action@v2
 
       - name: Set up Helm
         uses: azure/setup-helm@v3
@@ -41,7 +41,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       # run chart linting 

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v2
         with:
-          node_image: v1.27.2
+          node_image: kindest/node:v1.27.2
 
       - name: Set up Helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -68,7 +68,7 @@ jobs:
       # define charts to test with the --charts parameter
       - name: Run chart-testing (install)
         run: ct install --charts charts/portal --config charts/chart-testing-config.yaml
-        # if: steps.list-changed.outputs.changed == 'true'
+        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
 
         # Upgrade the release portal chart version with the locally available chart
       - name: Run helm upgrade
@@ -78,4 +78,4 @@ jobs:
           helm install portal --version ${{ github.event.inputs.upgrade_from }} tractusx-dev/portal
           helm dependency update charts/portal
           helm upgrade portal charts/portal
-        # if: steps.list-changed.outputs.changed == 'true'
+        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -55,4 +55,4 @@ jobs:
       # define charts to test with the --charts parameter
       - name: Run chart-testing (install)
         run: ct install --charts charts/portal --config charts/chart-testing-config.yaml
-        if: steps.list-changed.outputs.changed == 'true'
+        # if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -1,6 +1,6 @@
 name: Portal Lint and Test Chart
 
-on: 
+on:
   push:
     paths:
       - 'charts/portal/**'

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v2
         with:
+          version: v0.19.0
           node_image: kindest/node:v1.25.3
 
       - name: Set up Helm

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v2
         with:
-          node-image: v1.27.2
+          node_image: v1.27.2
 
       - name: Set up Helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v2
+        with:
+          node-image: v1.27.2
 
       - name: Set up Helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -16,6 +16,12 @@ on:
         default: 'kindest/node:v1.24.6'
         required: false
         type: string
+      upgrade_from:
+        description: 'portal chart version to upgrade from'
+        # portal version from 3.1 release
+        default: '1.3.0'
+        required: false
+        type: string
 
 jobs:
   lint-test:
@@ -62,4 +68,14 @@ jobs:
       # define charts to test with the --charts parameter
       - name: Run chart-testing (install)
         run: ct install --charts charts/portal --config charts/chart-testing-config.yaml
+        # if: steps.list-changed.outputs.changed == 'true'
+
+        # Upgrade the release portal chart version with the locally available chart
+      - name: Run helm upgrade
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+          helm install portal --version ${{ github.event.inputs.upgrade_from }} tractusx-dev/portal
+          helm dependency update charts/portal
+          helm upgrade portal charts/portal
         # if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: container-tools/kind-action@v2
         with:
           version: v0.19.0
-          node_image: kindest/node:v1.25.3
+          node_image: kindest/node:v1.24.6
 
       - name: Set up Helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -1,6 +1,6 @@
 name: Portal Lint and Test Chart
 
-on: 
+on:
   push:
     paths:
       - 'charts/portal/**'
@@ -47,6 +47,10 @@ jobs:
       # run chart linting 
       - name: Run chart-testing (lint)
         run: ct lint --charts charts/portal --config charts/chart-testing-config.yaml
+
+      # run chart linting 
+      - name: Run kubectl version
+        run: kubectl version
 
       # install the chart to the kind cluster and run helm test
       # define charts to test with the --charts parameter

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -36,13 +36,13 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
 
-      # - name: Run chart-testing (list-changed)
-      #   id: list-changed
-      #   run: |
-      #     changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
-      #     if [[ -n "$changed" ]]; then
-      #       echo "::set-output name=changed::true"
-      #     fi
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
 
       # run chart linting 
       - name: Run chart-testing (lint)
@@ -52,4 +52,4 @@ jobs:
       # define charts to test with the --charts parameter
       - name: Run chart-testing (install)
         run: ct install --charts charts/portal --config charts/chart-testing-config.yaml
-        # if: steps.list-changed.outputs.changed == 'true'
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -70,7 +70,7 @@ jobs:
         run: ct install --charts charts/portal --config charts/chart-testing-config.yaml
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
 
-        # Upgrade the release portal chart version with the locally available chart
+        # Upgrade the released portal chart version with the locally available chart
       - name: Run helm upgrade
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -19,6 +19,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Kubernetes KinD Cluster
+        uses: container-tools/kind-action@v1
+
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
@@ -27,7 +30,8 @@ jobs:
       # Setup python as a prerequisite for chart linting 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.9'
+          check-latest: true
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
@@ -43,11 +47,6 @@ jobs:
       # run chart linting 
       - name: Run chart-testing (lint)
         run: ct lint --charts charts/portal --config charts/chart-testing-config.yaml
-
-      # Preparing a kind cluster to install and test charts on
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.4.0
-        # if: steps.list-changed.outputs.changed == 'true'
 
       # install the chart to the kind cluster and run helm test
       # define charts to test with the --charts parameter

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -9,6 +9,13 @@ on:
     paths:
       - 'charts/portal/**'
   workflow_dispatch:
+    inputs:
+      node_image:
+        description: 'kindest/node image for k8s kind cluster'
+        # k8s version from 3.1 release
+        default: 'kindest/node:v1.24.6'
+        required: false
+        type: string
 
 jobs:
   lint-test:
@@ -23,7 +30,7 @@ jobs:
         uses: container-tools/kind-action@v2
         with:
           version: v0.19.0
-          node_image: kindest/node:v1.24.6
+          node_image: ${{ github.event.inputs.node_image }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v2
         with:
-          node_image: kindest/node:v1.27.2
+          node_image: kindest/node:v1.25.3
 
       - name: Set up Helm
         uses: azure/setup-helm@v3

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -425,7 +425,7 @@ backend:
     name: "portal-maintenance"
     image:
       name: "tractusx/portal-maintenance-service"
-      portalmaintenancetag: v1.4.0
+      portalmaintenancetag: 2681d4dbe7586774b793f24167b71a6c2568e60d
   notification:
     name: "notification-service"
     image:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -425,7 +425,7 @@ backend:
     name: "portal-maintenance"
     image:
       name: "tractusx/portal-maintenance-service"
-      portalmaintenancetag: 2681d4dbe7586774b793f24167b71a6c2568e60d
+      portalmaintenancetag: v1.4.0
   notification:
     name: "notification-service"
     image:


### PR DESCRIPTION
## Description

- enable testing of helm upgrade from different portal chart versions via workflow dispatch (default version set to the portal version 1.3.0,  from the latest tx release aka 3.1)
- enable testing with different k8s version via workflow dispatch (default version set to 1.24.6, as the 3.1 release was tested with that version)
- update helm test workflow as [trg helm test](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-09) was updated since introduction of the workflow
- uncomment and use list-changed step and improve for workflow dispatch usage

## Why

[trg upgradeability](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-11)
[trg k8s versions](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-10)

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have commented my changes, particularly in hard-to-understand areas
