### PR TITLE
fix(registration): configuration for documenttypeids for submitregistration

### DIFF
--- a/charts/portal/templates/deployment-backend-registration.yaml
+++ b/charts/portal/templates/deployment-backend-registration.yaml
@@ -160,6 +160,9 @@ spec:
           value: "{{ .Values.backend.registration.swaggerEnabled }}"
         - name: "REGISTRATION__REGISTRATIONDOCUMENTTYPEIDS__0"
           value: "{{ .Values.backend.registration.registrationDocumentTypeIds.type0 }}"
+        - name: "REGISTRATION__SUBMITDOCUMENTTYPEIDS__0"
+          value: "{{ .Values.backend.registration.submitDocumentTypeIds.type0 }}"
+
         ports:
         - name: http
           containerPort: {{ .Values.portContainer }}

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -289,6 +289,8 @@ backend:
     swaggerEnabled: false
     registrationDocumentTypeIds:
       type0: "CX_FRAME_CONTRACT"
+    submitDocumentTypeIds:
+      type0: "COMMERCIAL_REGISTER_EXTRACT"
   administration:
     name: "administration-service"
     image:


### PR DESCRIPTION
## Description

Added Configuration for document type Ids for submit registration end point in registration service
backend PR is https://github.com/eclipse-tractusx/portal-backend/pull/82

## Why

Setting is required to avoid hard coded value in code and can be configured at any time

## Issue
CPLP-2736

Link to pull request from other repository.

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
