### PR TITLE
feat(seeding): add configuration for seeding path

### DIFF
--- a/charts/portal/templates/job-backend-portal-migrations.yaml
+++ b/charts/portal/templates/job-backend-portal-migrations.yaml
@@ -62,6 +62,8 @@ spec:
           {{- end }}
           - name: "SEEDING__TESTDATAENVIRONMENTS__0"
             value: "{{ .Values.backend.portalmigrations.seeding.testDataEnvironments }}"
+          - name: "SEEDING__DATAPATHS__0"
+            value: "{{ .Values.backend.portalmigrations.seeding.testDataPaths }}"
         ports:
         - name: http
           containerPort: {{ .Values.portContainer }}

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -511,6 +511,7 @@ backend:
       #   memory: 256Mi
     seeding:
       testDataEnvironments: ""
+      testDataPaths: "Seeder/Data"
   portalmaintenance:
     name: "portal-maintenance"
     image:


### PR DESCRIPTION
## Description

Added configuration for the seeding to use the Seeder/Data directory

## Why

To be able to seed ones own data and don't have the need to edit the json files within the Seeder/Data directory one can now mount a directory which than can be configured to be used for the seeding as well.

## Issue

N/A - Jira Issue: CPLP-2788

## Corresponding Backend PR

[#108](https://github.com/eclipse-tractusx/portal-backend/pull/108)

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
