### PR TITLE
fix(logging): change name of env variables

### DIFF
--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -281,7 +281,7 @@ spec:
               key: "shared-client-secret"
         - name: "KEYCLOAK__SHARED__CONNECTIONSTRING"
           value: "{{ .Values.sharedidpAddress }}"
-        - name: "LOGGING__LOGLEVEL__ORG.CATENAX.NG.PORTAL.BACKEND.ADMINISTRATION.SERVICE.BUSINESSLOGIC"
+        - name: "LOGGING__LOGLEVEL__ORG.ECLIPSE.TRACTUSX.PORTAL.BACKEND.ADMINISTRATION.SERVICE.BUSINESSLOGIC"
           value: "{{ .Values.backend.administration.logging.businessLogic }}"
         - name: "LOGGING__LOGLEVEL__ORG.ECLIPSE.TRACTUSX.PORTAL.BACKEND.SDFACTORY.LIBRARY"
           value: "{{ .Values.backend.administration.logging.sdfactoryLibrary }}"

--- a/charts/portal/templates/deployment-backend-appmarketplace.yaml
+++ b/charts/portal/templates/deployment-backend-appmarketplace.yaml
@@ -233,7 +233,7 @@ spec:
               key: "shared-client-secret"
         - name: "KEYCLOAK__SHARED__CONNECTIONSTRING"
           value: "{{ .Values.sharedidpAddress }}"
-        - name: "LOGGING__LOGLEVEL__ORG.CATENAX.NG.PORTAL.BACKEND.OFFERS.LIBRARY.SERVICE"
+        - name: "LOGGING__LOGLEVEL__ORG.ECLIPSE.TRACTUSX.PORTAL.BACKEND.OFFERS.LIBRARY.SERVICE"
           value: "{{ .Values.backend.appmarketplace.logging.offersLibrary }}"
         - name: "MAILINGSERVICE__MAIL__SMTPHOST"
           value: "{{ .Values.backend.mailing.host }}"

--- a/charts/portal/templates/deployment-backend-registration.yaml
+++ b/charts/portal/templates/deployment-backend-registration.yaml
@@ -123,7 +123,7 @@ spec:
               key: "shared-client-secret"
         - name: "KEYCLOAK__SHARED__CONNECTIONSTRING"
           value: "{{ .Values.sharedidpAddress }}"
-        - name: "LOGGING__LOGLEVEL__ORG.CATENAX.NG.PORTAL.BACKEND.REGISTRATION.SERVICE.BPN"
+        - name: "LOGGING__LOGLEVEL__ORG.ECLIPSE.TRACTUSX.PORTAL.BACKEND.REGISTRATION.SERVICE.BPN"
           value: "{{ .Values.backend.registration.logging.registrationServiceBpn }}"
         - name: "MAILINGSERVICE__MAIL__SMTPHOST"
           value: "{{ .Values.backend.mailing.host }}"

--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -115,7 +115,7 @@ spec:
               key: "shared-client-secret"
         - name: "KEYCLOAK__SHARED__CONNECTIONSTRING"
           value: "{{ .Values.sharedidpAddress }}"
-        - name: "LOGGING__LOGLEVEL__ORG.CATENAX.NG.PORTAL.BACKEND.OFFERS.LIBRARY.SERVICE"
+        - name: "LOGGING__LOGLEVEL__ORG.ECLIPSE.TRACTUSX.PORTAL.BACKEND.OFFERS.LIBRARY.SERVICE"
           value: "{{ .Values.backend.services.logging.offersLibrary }}"
         - name: "MAILINGSERVICE__MAIL__SMTPHOST"
           value: "{{ .Values.backend.mailing.host }}"


### PR DESCRIPTION
## Description

fix name of environment variables for logging

## Why

when moving from catenax-ng to eclipse-tractusx GH org the renaming of some package names must have been forgotten in the config

## Issue

n/a

Link to pull request from other repository.

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
