### PR TITLE
chore: add documentation for seeding testDataPaths

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -511,7 +511,7 @@ backend:
       #   memory: 256Mi
     seeding:
       testDataEnvironments: ""
-      # when changing the testDataPath the processIdentity needs to be adjusted as well,
+      # -- when changing the testDataPath the processIdentity needs to be adjusted as well,
       # or it must be ensured that the identity is existing within the files under the new path
       testDataPaths: "Seeder/Data"
     processIdentity:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -509,14 +509,16 @@ backend:
       # requests:
       #   cpu: 250m
       #   memory: 256Mi
+    seeding:
+      testDataEnvironments: ""
+      # when changing the testDataPath the processIdentity needs to be adjusted as well,
+      # or it must be ensured that the identity is existing within the files under the new path
+      testDataPaths: "Seeder/Data"
     processIdentity:
       userEntityId: 090c9121-7380-4bb0-bb10-fffd344f930a
       processUserId: d21d2e8a-fe35-483c-b2b8-4100ed7f0953
       identityTypeId: 2
       processUserCompanyId: 2dc4249f-b5ca-4d42-bef1-7a7a950a4f87
-    seeding:
-      testDataEnvironments: ""
-      testDataPaths: "Seeder/Data"
     logging:
       default: "Information"
   portalmaintenance:


### PR DESCRIPTION
## Description

Add documentation for seeding testDataPaths

## Why

If changing the testDataPaths for the seeding the processIdentity needs to be adjusted as well

## Issue

N/A

## Corresponding Backend PR
[#214](https://github.com/eclipse-tractusx/portal-backend/pull/214)

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have commented my changes, particularly in hard-to-understand areas
