### PR TITLE
chore: add baseportal configuration

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -231,6 +231,8 @@ spec:
               value: "{{ .Values.backend.clients.registration }}"
             - name: "NETWORKREGISTRATION__INITIALROLES__0__USERROLENAMES__0"
               value: "{{ .Values.backend.provisioning.invitedUserInitialRoles.registration }}"
+            - name: "NETWORKREGISTRATION__BASEPORTALADDRESS"
+              value: "{{ .Values.portalAddress }}{{ .Values.backend.portalHomePath }}"
             - name: "MAILINGSERVICE__MAIL__SMTPPORT"
               value: "{{ .Values.backend.mailing.port }}"
             - name: "MAILINGSERVICE__MAIL__SMTPUSER"


### PR DESCRIPTION
## Description

Added base portal url to the network process

## Why

To have the basePortalUrl accessible in the network process

## Issue

N/A - Jira Issue: CPLP-3295

## Depending Backend PR

[#280](https://github.com/eclipse-tractusx/portal-backend/pull/280)

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes