### PR TITLE
fix(secrets): move quotes for escaping

### DIFF
--- a/charts/portal/templates/secret-backend-external-db.yaml
+++ b/charts/portal/templates/secret-backend-external-db.yaml
@@ -31,8 +31,8 @@ data:
   # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
   # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
   # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
-  portal-password: {{ ( .Values.externalDatabase.portalPassword | b64enc | quote ) | default ( index $secret.data "portal-password" ) }}
-  provisioning-password: {{ ( .Values.externalDatabase.provisioningPassword | b64enc | quote ) | default ( index $secret.data "provisioning-password" ) }}
+  portal-password: {{ ( .Values.externalDatabase.portalPassword | b64enc ) | default ( index $secret.data "portal-password" ) | quote }}
+  provisioning-password: {{ ( .Values.externalDatabase.provisioningPassword | b64enc ) | default ( index $secret.data "provisioning-password" ) | quote }}
 {{ else -}}
 stringData:
   # if secret doesn't exist, use provided value from values file or generate a random one

--- a/charts/portal/templates/secret-backend-interfaces.yaml
+++ b/charts/portal/templates/secret-backend-interfaces.yaml
@@ -30,13 +30,13 @@ data:
   # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret or generate a random one (if keys are added later on)
   # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
   # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
-  bpdm-client-secret: {{ coalesce ( .Values.backend.processesworker.bpdm.clientSecret | b64enc | quote ) ( index $secret.data "bpdm-client-secret" ) | default ( randAlphaNum 32 | quote ) }}
-  clearinghouse-client-secret: {{ coalesce ( .Values.backend.processesworker.clearinghouse.clientSecret | b64enc | quote ) ( index $secret.data "clearinghouse-client-secret" ) | default ( randAlphaNum 32 | quote ) }}
-  custodian-client-secret: {{ coalesce ( .Values.backend.processesworker.custodian.clientSecret | b64enc | quote ) ( index $secret.data "custodian-client-secret" ) | default ( randAlphaNum 32 | quote ) }}
-  sdfactory-client-secret: {{ coalesce ( .Values.backend.processesworker.sdfactory.clientSecret | b64enc | quote ) ( index $secret.data "sdfactory-client-secret" ) | default ( randAlphaNum 32 | quote ) }}
-  offerprovider-client-secret: {{ coalesce ( .Values.backend.processesworker.offerprovider.clientSecret | b64enc | quote ) ( index $secret.data "offerprovider-client-secret" ) | default ( randAlphaNum 32 | quote ) }}
-  onboardingserviceprovider-encryption-key: {{ coalesce ( .Values.backend.administration.onboardingServiceProvider.encryptionKey | b64enc | quote ) ( index $secret.data "onboardingserviceprovider-encryption-key" ) | default ( randAlphaNum 32 | quote ) }}
-  process-onboardingserviceprovider-encryption-key: {{ coalesce ( .Values.backend.processesworker.onboardingServiceProvider.encryptionKey | b64enc | quote ) ( index $secret.data "onboardingserviceprovider-encryption-key" ) | default ( randAlphaNum 32 | quote ) }}
+  bpdm-client-secret: {{ coalesce ( .Values.backend.processesworker.bpdm.clientSecret | b64enc ) ( index $secret.data "bpdm-client-secret" ) | default ( randAlphaNum 32 ) | quote }}
+  clearinghouse-client-secret: {{ coalesce ( .Values.backend.processesworker.clearinghouse.clientSecret | b64enc ) ( index $secret.data "clearinghouse-client-secret" ) | default ( randAlphaNum 32 ) | quote }}
+  custodian-client-secret: {{ coalesce ( .Values.backend.processesworker.custodian.clientSecret | b64enc ) ( index $secret.data "custodian-client-secret" ) | default ( randAlphaNum 32 ) | quote }}
+  sdfactory-client-secret: {{ coalesce ( .Values.backend.processesworker.sdfactory.clientSecret | b64enc ) ( index $secret.data "sdfactory-client-secret" ) | default ( randAlphaNum 32 ) | quote }}
+  offerprovider-client-secret: {{ coalesce ( .Values.backend.processesworker.offerprovider.clientSecret | b64enc ) ( index $secret.data "offerprovider-client-secret" ) | default ( randAlphaNum 32 ) | quote }}
+  onboardingserviceprovider-encryption-key: {{ coalesce ( .Values.backend.administration.onboardingServiceProvider.encryptionKey | b64enc ) ( index $secret.data "onboardingserviceprovider-encryption-key" ) | default ( randAlphaNum 32 ) | quote }}
+  process-onboardingserviceprovider-encryption-key: {{ coalesce ( .Values.backend.processesworker.onboardingServiceProvider.encryptionKey | b64enc ) ( index $secret.data "process-onboardingserviceprovider-encryption-key" ) | default ( randAlphaNum 32 ) | quote }}
 {{ else -}}
 stringData:
   # if secret doesn't exist, use provided value from values file or generate a random one

--- a/charts/portal/templates/secret-backend-keycloak.yaml
+++ b/charts/portal/templates/secret-backend-keycloak.yaml
@@ -30,9 +30,9 @@ data:
   # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
   # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
   # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
-  central-db-password: {{ ( .Values.backend.keycloak.central.dbConnection.password | b64enc | quote ) | default ( index $secret.data "central-db-password" ) }}
-  central-client-secret: {{ ( .Values.backend.keycloak.central.clientSecret | b64enc | quote ) | default ( index $secret.data "central-client-secret" ) }}
-  shared-client-secret: {{ ( .Values.backend.keycloak.shared.clientSecret | b64enc | quote ) | default ( index $secret.data "shared-client-secret" ) }}
+  central-db-password: {{ ( .Values.backend.keycloak.central.dbConnection.password | b64enc ) | default ( index $secret.data "central-db-password" ) | quote }}
+  central-client-secret: {{ ( .Values.backend.keycloak.central.clientSecret | b64enc ) | default ( index $secret.data "central-client-secret" ) | quote }}
+  shared-client-secret: {{ ( .Values.backend.keycloak.shared.clientSecret | b64enc ) | default ( index $secret.data "shared-client-secret" ) | quote }}
 {{ else -}}
 stringData:
   # if secret doesn't exist, use provided value from values file or generate a random one

--- a/charts/portal/templates/secret-backend-mailing.yaml
+++ b/charts/portal/templates/secret-backend-mailing.yaml
@@ -30,8 +30,8 @@ data:
   # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
   # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
   # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
-  password: {{ ( .Values.backend.mailing.password | b64enc | quote ) | default $secret.data.password }}
-  provisioning-sharedrealm-password: {{ ( .Values.backend.provisioning.sharedRealm.smtpServer.password | b64enc | quote ) | default ( index $secret.data "provisioning-sharedrealm-password" ) }}
+  password: {{ ( .Values.backend.mailing.password | b64enc ) | default $secret.data.password | quote }}
+  provisioning-sharedrealm-password: {{ ( .Values.backend.provisioning.sharedRealm.smtpServer.password | b64enc ) | default ( index $secret.data "provisioning-sharedrealm-password" ) | quote }}
 {{ else -}}
 stringData:
   # if secret doesn't exist, use provided value from values file or generate a random one

--- a/charts/portal/templates/secret-backend-postgres-init.yaml
+++ b/charts/portal/templates/secret-backend-postgres-init.yaml
@@ -31,10 +31,10 @@ data:
   # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
   # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
   # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
-  postgres-password: {{ ( .Values.postgresql.auth.password | b64enc )  | default ( index $secret.data "postgres-password" ) }}
-  replication-password: {{ ( .Values.postgresql.auth.replicationPassword | b64enc )  | default ( index $secret.data "replication-password" ) }}
-  portal-password: {{ ( .Values.postgresql.auth.portalPassword | b64enc ) | default ( index $secret.data "portal-password" ) }}
-  provisioning-password: {{ ( .Values.postgresql.auth.provisioningPassword | b64enc ) | default ( index $secret.data "provisioning-password" ) }}
+  postgres-password: {{ ( .Values.postgresql.auth.password | b64enc )  | default ( index $secret.data "postgres-password" ) | quote }}
+  replication-password: {{ ( .Values.postgresql.auth.replicationPassword | b64enc )  | default ( index $secret.data "replication-password" ) | quote }}
+  portal-password: {{ ( .Values.postgresql.auth.portalPassword | b64enc ) | default ( index $secret.data "portal-password" ) | quote }}
+  provisioning-password: {{ ( .Values.postgresql.auth.provisioningPassword | b64enc ) | default ( index $secret.data "provisioning-password" ) | quote }}
 {{ else -}}
 stringData:
   # if secret doesn't exist, use provided value from values file or generate a random one


### PR DESCRIPTION
## Description

fix placement of quotes for escaping
fix wrong key for [process-onboardingprovider](https://github.com/eclipse-tractusx/portal-cd/pull/101/files#diff-7f9045318b32510da44cb93dc7bfa26b1806adfc0e1e3879f02f38925d657e27R39)

## Why

led to empty values at helm upgrade

## Issue

relates to https://github.com/eclipse-tractusx/portal-cd/pull/90

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
