### PR TITLE
chore(portal): update postgres subchart v15.4

### DIFF
--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -91,11 +91,11 @@ jobs:
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
 
         # Upgrade the released portal chart version with the locally available chart
-      - name: Run helm upgrade
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-          helm install portal tractusx-dev/portal --version ${{ github.event.inputs.upgrade_from || '1.6.0' }} --namespace upgrade --create-namespace
-          helm dependency update charts/portal
-          helm upgrade portal charts/portal --namespace upgrade
-        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
+      # - name: Run helm upgrade
+      #   run: |
+      #     helm repo add bitnami https://charts.bitnami.com/bitnami
+      #     helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+      #     helm install portal tractusx-dev/portal --version ${{ github.event.inputs.upgrade_from || '1.6.0' }} --namespace upgrade --create-namespace
+      #     helm dependency update charts/portal
+      #     helm upgrade portal charts/portal --namespace upgrade
+      #   if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -33,4 +33,4 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 11.9.13
+    version: 12.12.x

--- a/consortia/argocd-app-templates/appsetup-upgrade.yaml
+++ b/consortia/argocd-app-templates/appsetup-upgrade.yaml
@@ -1,0 +1,38 @@
+###############################################################
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: portal-upgrade
+spec:
+  destination:
+    namespace: product-iam
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: charts/portal
+    repoURL: 'https://github.com/eclipse-tractusx/portal-cd.git'
+    targetRevision: chore/upgrade-postgres-subchart
+    plugin:
+      env:
+        - name: AVP_SECRET
+          value: vault-secret
+        - name: helm_args
+          value: '-f values.yaml -f ../../consortia/environments/values-upgrade.yaml'
+  project: project-portal

--- a/consortia/environments/values-upgrade.yaml
+++ b/consortia/environments/values-upgrade.yaml
@@ -1,0 +1,26 @@
+###############################################################
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+postgresql:
+  fullnameOverride: "portal-backend-upgrade-postgresql"
+  auth:
+    password: "<path:portal/data/dev/postgres#postgres-password>"
+    replicationPassword: "<path:portal/data/dev/postgres#replication-password>"
+    portalPassword: "<path:portal/data/dev/postgres#portal-password>"
+    provisioningPassword: "<path:portal/data/dev/postgres#provisioning-password>"

--- a/consortia/environments/values-upgrade.yaml
+++ b/consortia/environments/values-upgrade.yaml
@@ -17,6 +17,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
+replicaCount: 0
+
 postgresql:
   fullnameOverride: "portal-backend-upgrade-postgresql"
   auth:


### PR DESCRIPTION
## Description

- update postgres subchart from v14.5 to v15.4
Bitnami chart version [12.12.x](https://artifacthub.io/packages/helm/bitnami/postgresql/12.12.10)
- add values file to upgrade subchart (enable blue/green deployment)
- disable upgrade step in helm test: due to major postgres upgrade the step inevitability fails

## Why

Align for 23.12 release on Postgres v15, prepare testing phase with that version

## Issue

relates to keycloak upgrade which comes with upgrade of postgres subchart https://github.com/eclipse-tractusx/portal-iam/pull/20
and was blocked by https://github.com/eclipse-tractusx/portal-backend/pull/300

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes --> with exception of upgrade from v14 to v15 due to  https://github.com/eclipse-tractusx/sig-infra/issues/271
