### PR TITLE
docs(localdev): improve readme

### DIFF
--- a/.github/workflows/localdev-chart-test.yaml
+++ b/.github/workflows/localdev-chart-test.yaml
@@ -24,9 +24,9 @@ on:
   #   paths:
   #     - 'charts/localdev/**'
   #   branches: [main, dev]
-  pull_request:
-    paths:
-      - 'charts/localdev/**'
+  # pull_request:
+  #   paths:
+  #     - 'charts/localdev/**'
   workflow_dispatch:
     inputs:
       node_image:

--- a/.github/workflows/localdev-chart-test.yaml
+++ b/.github/workflows/localdev-chart-test.yaml
@@ -20,10 +20,10 @@
 name: LocalDev Lint and Test Chart
 
 on:
-  push:
-    paths:
-      - 'charts/localdev/**'
-    branches: [main, dev]
+  # push:
+  #   paths:
+  #     - 'charts/localdev/**'
+  #   branches: [main, dev]
   pull_request:
     paths:
       - 'charts/localdev/**'

--- a/charts/localdev/README.md
+++ b/charts/localdev/README.md
@@ -42,7 +42,7 @@ The following steps describe how to setup the LocalDev chart into the namespace 
 1. [Prepare self-signed TLS setup](#1-prepare-self-signed-tls-setup)
 2. [Prepare network setup](#2-prepare-network-setup)
 3. [Install from released chart or portal-cd repository](#3-install-from-released-chart-or-portal-cd-repository)
-4. [Perform first login](perform-first-login)
+4. [Perform first login](#4-perform-first-login)
 
 ### 1. Prepare self-signed TLS setup
 
@@ -105,13 +105,13 @@ See [cert-manager self-signed](https://cert-manager.io/docs/configuration/selfsi
 
 ### 2. Prepare network setup
 
-In order to enable the local access via ingress, use the according addon for Minikube:
+In order to enable the local access via **ingress**, use the according addon for Minikube:
 
 ```bash
 minikube addons enable ingress
 ```
 
-Make sure that the DNS resolution for the hostnames is in place:
+Make sure that the **DNS** resolution for the hostnames is in place:
 
 ```bash
 minikube addons enable ingress-dns
@@ -132,7 +132,17 @@ To find out the IP address of your Minikube:
 minikube ip
 ```
 
-Additional network setup for Mac only:
+If afterwards at [step 4](#4-perform-first-login) your still facing DNS issues, add the following to your /etc/hosts file:
+
+  192.168.49.2    centralidp.example.org
+  192.168.49.2    sharedidp.example.org
+  192.168.49.2    portal.example.org
+  192.168.49.2    portal-backend.example.org
+  192.168.49.2    pgadmin4.example.org
+
+Replace 192.168.49.2 with your minikube ip.
+
+**Additional network setup** (for Mac only)
 
 Install and start [Docker Mac Net Connect](https://github.com/chipmk/docker-mac-net-connect#installation).
 
@@ -189,6 +199,12 @@ To set your own configuration and secret values, install the helm chart with you
 helm install local -f your-values.yaml . --namespace localdev
 ```
 
+> **Note**
+>
+> It is to be expected that the pods for the **portal-migrations** job will run into an error a couple of times until the portal database is ready to take connections.
+> The job will recreate pods until one run is successful.
+>
+
 ### 4. Perform first login
 
 Make sure to accept the risk of the self-signed certificates for the following hosts using the continue option:
@@ -198,7 +214,7 @@ Make sure to accept the risk of the self-signed certificates for the following h
 - [portal.example.org](https://portal.example.org)
 - [pgadmin4.example.org](https://pgadmin4.example.org)
 
-Then proceed with the login to [portal.example.org](https://portal.example.org).
+Then proceed with the login to the [portal](https://portal.example.org) to verify that everything is setup as expected.
 
 Credentials to log into the initial example realm (CX-Operator):
 

--- a/charts/localdev/README.md
+++ b/charts/localdev/README.md
@@ -30,7 +30,7 @@ The following steps describe how to setup the LocalDev chart into the namespace 
 > |     2      |      6     |
 >
 >```bash
->minikube start --cpus=2 --memory 6gb
+> minikube start --cpus=2 --memory 6gb
 >```
 >
 > Use the dashboard provided by Minikube to get an overview about the deployed components:

--- a/charts/localdev/README.md
+++ b/charts/localdev/README.md
@@ -210,6 +210,38 @@ cx-operator@cx.com
 7XSXRwYLAm5kU2H
 ```
 
+```mermaid
+%%{
+  init: {
+    'flowchart': { 'diagramPadding': '10', 'wrappingWidth': '', 'nodeSpacing': '', 'rankSpacing':'', 'titleTopMargin':'10', 'curve':'basis'},
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#b3cb2d',
+      'primaryBorderColor': '#ffa600',
+      'lineColor': '#ffa600',
+      'tertiaryColor': '#fff'
+    }
+  }
+}%%
+        graph TD
+          classDef stroke stroke-width:2px
+          classDef external fill:#4cb5f5,stroke:#4cb5f5,stroke-width:2px
+          classDef addext fill:#4cb5f5,stroke:#b7b8b6,stroke-width:2px
+          iam1(IAM: centralidp Keycloak):::stroke
+          iam2(IAM: sharedidp Keycloak):::stroke
+          portal(Portal):::stroke
+          ps(Postgres):::external
+          addpgadmin4(pgadmin 4):::addext
+          ps --- iam1 & iam2 & portal
+          ps -.- addpgadmin4
+          subgraph Login Flow
+            iam1 === portal
+            iam1 === iam2
+            end
+          linkStyle 0,1,2 stroke:lightblue
+          linkStyle 3 stroke:lightgrey
+```
+
 ## Requirements
 
 | Repository | Name | Version |

--- a/charts/localdev/README.md
+++ b/charts/localdev/README.md
@@ -12,7 +12,7 @@ For detailed information about the default configuration values, please have a l
 
 ## Usage
 
-The following steps describe how to setup the LocalDev chart into the namespace 'localdev' of your started [**Minikube**](https://minikube.sigs.k8s.io/docs/start) cluster:
+The following steps describe how to setup the LocalDev chart into the namespace 'localdev' of your started [**Minikube**](https://minikube.sigs.k8s.io/docs/start) cluster.
 
 > **Note**
 >
@@ -28,6 +28,10 @@ The following steps describe how to setup the LocalDev chart into the namespace 
 > | CPU(cores) | Memory(GB) |
 > | :--------: | :--------: |
 > |     2      |      6     |
+>
+>```bash
+>minikube start --cpus=2 --memory 6gb
+>```
 >
 > Use the dashboard provided by Minikube to get an overview about the deployed components:
 >
@@ -130,9 +134,13 @@ minikube ip
 
 Additional network setup for Mac only:
 
-Install and start [docker-mac-net-connect](https://github.com/chipmk/docker-mac-net-connect#installation).
+Install and start [Docker Mac Net Connect](https://github.com/chipmk/docker-mac-net-connect#installation).
 
-Necessary due to [#7332](https://github.com/kubernetes/minikube/issues/7332).
+We also recommend to execute the usage example after install to check proper setup.
+
+If you're having issues with getting 'Docker Mac Net Connect' to work, we recommend to check out this issue: [#21](https://github.com/chipmk/docker-mac-net-connect/issues/21).
+
+The tool is necessary due to [#7332](https://github.com/kubernetes/minikube/issues/7332).
 
 ### 3. Install from released chart or [portal-cd](https://github.com/eclipse-tractusx/portal-cd) repository
 
@@ -142,6 +150,9 @@ Install the chart with the release name 'local':
 
 ```bash
 helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+```
+
+```bash
 helm install local tractusx-dev/localdev-portal-iam --namespace localdev
 ```
 

--- a/charts/localdev/README.md
+++ b/charts/localdev/README.md
@@ -134,11 +134,13 @@ minikube ip
 
 If afterwards at [step 4](#4-perform-first-login) your still facing DNS issues, add the following to your /etc/hosts file:
 
-  192.168.49.2    centralidp.example.org
-  192.168.49.2    sharedidp.example.org
-  192.168.49.2    portal.example.org
-  192.168.49.2    portal-backend.example.org
-  192.168.49.2    pgadmin4.example.org
+```
+192.168.49.2    centralidp.example.org
+192.168.49.2    sharedidp.example.org
+192.168.49.2    portal.example.org
+192.168.49.2    portal-backend.example.org
+192.168.49.2    pgadmin4.example.org
+```
 
 Replace 192.168.49.2 with your minikube ip.
 

--- a/charts/localdev/README.md.gotmpl
+++ b/charts/localdev/README.md.gotmpl
@@ -135,11 +135,13 @@ minikube ip
 
 If afterwards at [step 4](#4-perform-first-login) your still facing DNS issues, add the following to your /etc/hosts file:
 
-  192.168.49.2    centralidp.example.org
-  192.168.49.2    sharedidp.example.org
-  192.168.49.2    portal.example.org
-  192.168.49.2    portal-backend.example.org
-  192.168.49.2    pgadmin4.example.org
+```
+192.168.49.2    centralidp.example.org
+192.168.49.2    sharedidp.example.org
+192.168.49.2    portal.example.org
+192.168.49.2    portal-backend.example.org
+192.168.49.2    pgadmin4.example.org
+```
 
 Replace 192.168.49.2 with your minikube ip.
 

--- a/charts/localdev/README.md.gotmpl
+++ b/charts/localdev/README.md.gotmpl
@@ -12,7 +12,7 @@ For detailed information about the default configuration values, please have a l
 
 ## Usage
 
-The following steps describe how to setup the LocalDev chart into the namespace 'localdev' of your started [**Minikube**](https://minikube.sigs.k8s.io/docs/start) cluster:
+The following steps describe how to setup the LocalDev chart into the namespace 'localdev' of your started [**Minikube**](https://minikube.sigs.k8s.io/docs/start) cluster.
 
 > **Note**
 >
@@ -29,11 +29,16 @@ The following steps describe how to setup the LocalDev chart into the namespace 
 > | :--------: | :--------: |
 > |     2      |      6     |
 >
+>```bash
+>minikube start --cpus=2 --memory 6gb
+>```
+>
 > Use the dashboard provided by Minikube to get an overview about the deployed components:
 >
 > ```bash 
 > minikube dashboard
 > ```
+
 
 1. [Prepare self-signed TLS setup](#1-prepare-self-signed-tls-setup)
 2. [Prepare network setup](#2-prepare-network-setup)
@@ -130,9 +135,13 @@ minikube ip
 
 Additional network setup for Mac only:
 
-Install and start [docker-mac-net-connect](https://github.com/chipmk/docker-mac-net-connect#installation).
+Install and start [Docker Mac Net Connect](https://github.com/chipmk/docker-mac-net-connect#installation).
 
-Necessary due to [#7332](https://github.com/kubernetes/minikube/issues/7332).
+We also recommend to execute the usage example after install to check proper setup.
+
+If you're having issues with getting 'Docker Mac Net Connect' to work, we recommend to check out this issue: [#21](https://github.com/chipmk/docker-mac-net-connect/issues/21).
+
+The tool is necessary due to [#7332](https://github.com/kubernetes/minikube/issues/7332).
 
 ### 3. Install from released chart or [portal-cd](https://github.com/eclipse-tractusx/portal-cd) repository
 
@@ -142,6 +151,9 @@ Install the chart with the release name 'local':
 
 ```bash
 helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+```
+
+```bash
 helm install local tractusx-dev/{{ template "chart.name" . }} --namespace localdev
 ```
 

--- a/charts/localdev/README.md.gotmpl
+++ b/charts/localdev/README.md.gotmpl
@@ -211,6 +211,38 @@ cx-operator@cx.com
 7XSXRwYLAm5kU2H
 ```
 
+```mermaid
+%%{
+  init: {
+    'flowchart': { 'diagramPadding': '10', 'wrappingWidth': '', 'nodeSpacing': '', 'rankSpacing':'', 'titleTopMargin':'10', 'curve':'basis'},
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#b3cb2d',
+      'primaryBorderColor': '#ffa600',
+      'lineColor': '#ffa600',
+      'tertiaryColor': '#fff'
+    }
+  }
+}%%
+        graph TD
+          classDef stroke stroke-width:2px
+          classDef external fill:#4cb5f5,stroke:#4cb5f5,stroke-width:2px
+          classDef addext fill:#4cb5f5,stroke:#b7b8b6,stroke-width:2px
+          iam1(IAM: centralidp Keycloak):::stroke
+          iam2(IAM: sharedidp Keycloak):::stroke
+          portal(Portal):::stroke
+          ps(Postgres):::external
+          addpgadmin4(pgadmin 4):::addext
+          ps --- iam1 & iam2 & portal
+          ps -.- addpgadmin4
+          subgraph Login Flow
+            iam1 === portal
+            iam1 === iam2
+            end
+          linkStyle 0,1,2 stroke:lightblue
+          linkStyle 3 stroke:lightgrey
+```
+
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}

--- a/charts/localdev/README.md.gotmpl
+++ b/charts/localdev/README.md.gotmpl
@@ -30,7 +30,7 @@ The following steps describe how to setup the LocalDev chart into the namespace 
 > |     2      |      6     |
 >
 >```bash
->minikube start --cpus=2 --memory 6gb
+> minikube start --cpus=2 --memory 6gb
 >```
 >
 > Use the dashboard provided by Minikube to get an overview about the deployed components:

--- a/charts/localdev/README.md.gotmpl
+++ b/charts/localdev/README.md.gotmpl
@@ -43,7 +43,7 @@ The following steps describe how to setup the LocalDev chart into the namespace 
 1. [Prepare self-signed TLS setup](#1-prepare-self-signed-tls-setup)
 2. [Prepare network setup](#2-prepare-network-setup)
 3. [Install from released chart or portal-cd repository](#3-install-from-released-chart-or-portal-cd-repository)
-4. [Perform first login](perform-first-login)
+4. [Perform first login](#4-perform-first-login)
 
 ### 1. Prepare self-signed TLS setup
 
@@ -106,13 +106,13 @@ See [cert-manager self-signed](https://cert-manager.io/docs/configuration/selfsi
 
 ### 2. Prepare network setup
 
-In order to enable the local access via ingress, use the according addon for Minikube:
+In order to enable the local access via **ingress**, use the according addon for Minikube:
 
 ```bash
 minikube addons enable ingress
 ```
 
-Make sure that the DNS resolution for the hostnames is in place:
+Make sure that the **DNS** resolution for the hostnames is in place:
 
 ```bash
 minikube addons enable ingress-dns
@@ -133,7 +133,17 @@ To find out the IP address of your Minikube:
 minikube ip
 ```
 
-Additional network setup for Mac only:
+If afterwards at [step 4](#4-perform-first-login) your still facing DNS issues, add the following to your /etc/hosts file:
+
+  192.168.49.2    centralidp.example.org
+  192.168.49.2    sharedidp.example.org
+  192.168.49.2    portal.example.org
+  192.168.49.2    portal-backend.example.org
+  192.168.49.2    pgadmin4.example.org
+
+Replace 192.168.49.2 with your minikube ip.
+
+**Additional network setup** (for Mac only)
 
 Install and start [Docker Mac Net Connect](https://github.com/chipmk/docker-mac-net-connect#installation).
 
@@ -190,6 +200,12 @@ To set your own configuration and secret values, install the helm chart with you
 helm install local -f your-values.yaml . --namespace localdev
 ```
 
+> **Note**
+>
+> It is to be expected that the pods for the **portal-migrations** job will run into an error a couple of times until the portal database is ready to take connections.
+> The job will recreate pods until one run is successful.
+>
+
 ### 4. Perform first login
 
 Make sure to accept the risk of the self-signed certificates for the following hosts using the continue option:
@@ -199,7 +215,7 @@ Make sure to accept the risk of the self-signed certificates for the following h
 - [portal.example.org](https://portal.example.org)
 - [pgadmin4.example.org](https://pgadmin4.example.org)
 
-Then proceed with the login to [portal.example.org](https://portal.example.org).
+Then proceed with the login to the [portal](https://portal.example.org) to verify that everything is setup as expected.
 
 Credentials to log into the initial example realm (CX-Operator):
 


### PR DESCRIPTION
## Description

- improve readme:
  - add graph for 1rst login example
  - add note for portal-migrations job failing until portal database is ready to take connections
  - add option for /etc/hosts file under network setup
  - re-add additional mac setup (wasn't part of readme tmpl the last and got lost)

- disable helm test for push and PR as it sometimes runs successfully in 4 minutes and other times fails after 20 minutes, it's not reliable

## Why

improve LocalDev umbrella chart

## Issue

relates to https://github.com/eclipse-tractusx/portal-cd/pull/90

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
