### PR TITLE
fix(portal): revert db name change for subchart

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -789,7 +789,7 @@ postgresql:
   # Switch to enable or disable the PostgreSQL helm chart
   enabled: true
   # -- FullnameOverride to 'portal-backend-postgresql'.
-  fullnameOverride: "portal-backend-upgrade-postgresql"
+  fullnameOverride: "portal-backend-postgresql"
   auth:
     # -- Database name
     database: "postgres"

--- a/consortia/argocd-app-templates/appsetup-dev.yaml
+++ b/consortia/argocd-app-templates/appsetup-dev.yaml
@@ -20,10 +20,10 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: portal
+  name: portal-upgrade
 spec:
   destination:
-    namespace: product-portal
+    namespace: product-iam
     server: 'https://kubernetes.default.svc'
   source:
     path: charts/portal

--- a/consortia/argocd-app-templates/appsetup-int.yaml
+++ b/consortia/argocd-app-templates/appsetup-int.yaml
@@ -20,7 +20,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: portal
+  name: portal-upgrade
 spec:
   destination:
     namespace: product-portal

--- a/consortia/argocd-app-templates/appsetup-upgrade.yaml
+++ b/consortia/argocd-app-templates/appsetup-upgrade.yaml
@@ -20,15 +20,15 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: portal-upgrade
+  name: portal
 spec:
   destination:
-    namespace: product-iam
+    namespace: product-portal
     server: 'https://kubernetes.default.svc'
   source:
     path: charts/portal
     repoURL: 'https://github.com/eclipse-tractusx/portal-cd.git'
-    targetRevision: chore/upgrade-postgres-subchart
+    targetRevision: upgrade
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/environments/values-upgrade.yaml
+++ b/consortia/environments/values-upgrade.yaml
@@ -20,7 +20,6 @@
 replicaCount: 0
 
 postgresql:
-  fullnameOverride: "portal-backend-upgrade-postgresql"
   auth:
     password: "<path:portal/data/dev/postgres#postgres-password>"
     replicationPassword: "<path:portal/data/dev/postgres#replication-password>"


### PR DESCRIPTION
## Description

revert db name change for subchart
and upgrade argoCd apptemplates

## Why

noticed after https://github.com/eclipse-tractusx/portal-cd/pull/107 that name change wasn't necessary.


## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
