### PR TITLE
fix(activation): adjust mail link

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -98,7 +98,7 @@ spec:
               value: "{{ .Values.backend.processesworker.applicationActivation.welcomeNotificationTypeIds.type4 }}"
             - name: "APPLICATIONACTIVATION__LOGINTHEME"
               value: "{{ .Values.backend.processesworker.applicationActivation.loginTheme }}"
-            - name: "APPLICATIONACTIVATION__HOMEADDRESS"
+            - name: "APPLICATIONACTIVATION__PORTALHOMEADDRESS"
               value: "{{ .Values.portalAddress }}{{ .Values.backend.portalHomePath }}"
             - name: "APPLICATIONACTIVATION__PASSWORDRESENDADDRESS"
               value: "{{ .Values.portalAddress }}{{ .Values.backend.portalPasswordResendPath }}"


### PR DESCRIPTION
## Description

Adjustig the application activation login link

## Why

Currently the wrong environment variable is set, therefore the link isn't set correctly and will be empty in the mail

## Issue

N/A - Jira Issue: CPLP-3525

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
