### PR TITLE
chore: slimline process identity config

### DIFF
--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -300,19 +300,13 @@ dependencies:
 | backend.portalmigrations.resources | object | `{"requests":{"cpu":"15m","memory":"105M"}}` | We recommend not to specify default resource limits and to leave this as a conscious choice for the user. If you do want to specify resource limits, uncomment the following lines and adjust them as necessary. |
 | backend.portalmigrations.seeding.testDataEnvironments | string | `""` |  |
 | backend.portalmigrations.seeding.testDataPaths | string | `"Seeder/Data"` | when changing the testDataPath the processIdentity needs to be adjusted as well, or it must be ensured that the identity is existing within the files under the new path |
-| backend.portalmigrations.processIdentity.userEntityId | string | `"090c9121-7380-4bb0-bb10-fffd344f930a"` |  |
 | backend.portalmigrations.processIdentity.processUserId | string | `"d21d2e8a-fe35-483c-b2b8-4100ed7f0953"` |  |
-| backend.portalmigrations.processIdentity.identityTypeId | int | `2` |  |
-| backend.portalmigrations.processIdentity.processUserCompanyId | string | `"2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"` |  |
 | backend.portalmigrations.logging.default | string | `"Information"` |  |
 | backend.portalmaintenance.name | string | `"portal-maintenance"` |  |
 | backend.portalmaintenance.image.name | string | `"tractusx/portal-maintenance-service"` |  |
 | backend.portalmaintenance.image.portalmaintenancetag | string | `"v1.7.0-RC3"` |  |
 | backend.portalmaintenance.resources | object | `{"requests":{"cpu":"15m","memory":"105M"}}` | We recommend not to specify default resource limits and to leave this as a conscious choice for the user. If you do want to specify resource limits, uncomment the following lines and adjust them as necessary. |
-| backend.portalmaintenance.processIdentity.userEntityId | string | `"090c9121-7380-4bb0-bb10-fffd344f930a"` |  |
 | backend.portalmaintenance.processIdentity.processUserId | string | `"d21d2e8a-fe35-483c-b2b8-4100ed7f0953"` |  |
-| backend.portalmaintenance.processIdentity.identityTypeId | int | `2` |  |
-| backend.portalmaintenance.processIdentity.processUserCompanyId | string | `"2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"` |  |
 | backend.portalmaintenance.logging.default | string | `"Information"` |  |
 | backend.notification.name | string | `"notification-service"` |  |
 | backend.notification.image.name | string | `"tractusx/portal-notification-service"` |  |
@@ -414,10 +408,7 @@ dependencies:
 | backend.processesworker.offerprovider.grantType | string | `"client_credentials"` |  |
 | backend.processesworker.offerprovider.clientId | string | `"offerprovider-client-id"` | Provide offerprovider client-id from CX IAM centralidp. |
 | backend.processesworker.offerprovider.clientSecret | string | `""` | Client-secret for offer provider client-id. Secret-key 'offerprovider-client-secret'. |
-| backend.processesworker.processIdentity.userEntityId | string | `"090c9121-7380-4bb0-bb10-fffd344f930a"` |  |
 | backend.processesworker.processIdentity.processUserId | string | `"d21d2e8a-fe35-483c-b2b8-4100ed7f0953"` |  |
-| backend.processesworker.processIdentity.identityTypeId | int | `2` |  |
-| backend.processesworker.processIdentity.processUserCompanyId | string | `"2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"` |  |
 | backend.processesworker.onboardingServiceProvider.encryptionKey | string | `""` | Client-secret for onboardingserviceprovider encryptionKey. Secret-key 'process-onboardingserviceprovider-encryption-key'. |
 | backend.processesworker.networkRegistration.loginDocumentPath | string | `"/documentation/?path=docs%2F09.+Others%28s%29%2F01.+Login.md"` |  |
 | backend.processesworker.networkRegistration.externalRegistrationPath | string | `"/?overlay=consent_osp"` |  |

--- a/charts/portal/templates/cronjob-backend-portal-maintenance.yaml
+++ b/charts/portal/templates/cronjob-backend-portal-maintenance.yaml
@@ -59,14 +59,8 @@ spec:
               - name: "CONNECTIONSTRINGS__PORTALDB"
                 value: "Server={{ .Values.externalDatabase.host }};Database={{ .Values.externalDatabase.database }};Port={{ .Values.externalDatabase.port }};User Id={{ .Values.externalDatabase.portalUser }};Password=$(PORTAL_PASSWORD);Ssl Mode={{ .Values.backend.dbConnection.sslMode }};"
               {{- end }}
-              - name: "PROCESSIDENTITY__USERENTITYID"
-                value: "{{ .Values.backend.portalmaintenance.processIdentity.userEntityId }}"
               - name: "PROCESSIDENTITY__PROCESSUSERID"
                 value: "{{ .Values.backend.portalmaintenance.processIdentity.processUserId }}"
-              - name: "PROCESSIDENTITY__IDENTITYTYPEID"
-                value: "{{ .Values.backend.portalmaintenance.processIdentity.identityTypeId }}"
-              - name: "PROCESSIDENTITY__PROCESSUSERCOMPANYID"
-                value: "{{ .Values.backend.portalmaintenance.processIdentity.processUserCompanyId }}"
               - name: "SERILOG__MINIMUMLEVEL__Default"
                 value: "{{ .Values.backend.portalmaintenance.logging.default }}"
             ports:

--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -320,14 +320,8 @@ spec:
               value: "{{ .Values.backend.processesworker.offerprovider.scope }}"
             - name: "OFFERPROVIDER__USERNAME"
               value: "{{ .Values.backend.placeholder }}"
-            - name: "PROCESSIDENTITY__USERENTITYID"
-              value: "{{ .Values.backend.processesworker.processIdentity.userEntityId }}"
             - name: "PROCESSIDENTITY__PROCESSUSERID"
               value: "{{ .Values.backend.processesworker.processIdentity.processUserId }}"
-            - name: "PROCESSIDENTITY__IDENTITYTYPEID"
-              value: "{{ .Values.backend.processesworker.processIdentity.identityTypeId }}"
-            - name: "PROCESSIDENTITY__PROCESSUSERCOMPANYID"
-              value: "{{ .Values.backend.processesworker.processIdentity.processUserCompanyId }}"
             - name: "ONBOARDINGSERVICEPROVIDER__ENCYRPTIONKEY"
               valueFrom:
                 secretKeyRef:

--- a/charts/portal/templates/job-backend-portal-migrations.yaml
+++ b/charts/portal/templates/job-backend-portal-migrations.yaml
@@ -68,14 +68,8 @@ spec:
             value: "{{ .Values.backend.portalmigrations.seeding.testDataPaths }}"
           - name: "SERILOG__MINIMUMLEVEL__Default"
             value: "{{ .Values.backend.portalmigrations.logging.default }}"
-          - name: "PROCESSIDENTITY__USERENTITYID"
-            value: "{{ .Values.backend.portalmigrations.processIdentity.userEntityId }}"
           - name: "PROCESSIDENTITY__PROCESSUSERID"
             value: "{{ .Values.backend.portalmigrations.processIdentity.processUserId }}"
-          - name: "PROCESSIDENTITY__IDENTITYTYPEID"
-            value: "{{ .Values.backend.portalmigrations.processIdentity.identityTypeId }}"
-          - name: "PROCESSIDENTITY__PROCESSUSERCOMPANYID"
-            value: "{{ .Values.backend.portalmigrations.processIdentity.processUserCompanyId }}"
         ports:
         - name: http
           containerPort: {{ .Values.portContainer }}

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -554,10 +554,7 @@ backend:
       # or it must be ensured that the identity is existing within the files under the new path
       testDataPaths: "Seeder/Data"
     processIdentity:
-      userEntityId: 090c9121-7380-4bb0-bb10-fffd344f930a
       processUserId: d21d2e8a-fe35-483c-b2b8-4100ed7f0953
-      identityTypeId: 2
-      processUserCompanyId: 2dc4249f-b5ca-4d42-bef1-7a7a950a4f87
     logging:
       default: "Information"
   portalmaintenance:
@@ -575,10 +572,7 @@ backend:
       #   cpu: 45m
       #   memory: 105M
     processIdentity:
-      userEntityId: 090c9121-7380-4bb0-bb10-fffd344f930a
       processUserId: d21d2e8a-fe35-483c-b2b8-4100ed7f0953
-      identityTypeId: 2
-      processUserCompanyId: 2dc4249f-b5ca-4d42-bef1-7a7a950a4f87
     logging:
       default: "Information"
   notification:
@@ -787,10 +781,7 @@ backend:
       # -- Client-secret for offer provider client-id. Secret-key 'offerprovider-client-secret'.
       clientSecret: ""
     processIdentity:
-      userEntityId: 090c9121-7380-4bb0-bb10-fffd344f930a
       processUserId: d21d2e8a-fe35-483c-b2b8-4100ed7f0953
-      identityTypeId: 2
-      processUserCompanyId: 2dc4249f-b5ca-4d42-bef1-7a7a950a4f87
     onboardingServiceProvider:
       # -- Client-secret for onboardingserviceprovider encryptionKey. Secret-key 'process-onboardingserviceprovider-encryption-key'.
       encryptionKey: ""


### PR DESCRIPTION
## Description

Some of the values required to configure the processIdentity were removed in the backend, therefor the configurations were removed in the cd repo as well.

## Why

The determination of the needed values is made in the backend.

## Issue

N/A - Jira Issue: CPLP-3102

## Corresponding Backend PR

[#361](https://github.com/eclipse-tractusx/portal-backend/pull/361)

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
