### PR TITLE
feat(registration): add configuration for new decline registration data endpoint

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -289,6 +289,13 @@ backend:
       status0: "SUBMITTED"
       status1: "DECLINED"
       status2: "CONFIRMED"
+    applicationDeclineStatusIds:
+      status0: "CREATED"
+      status1: "ADD_COMPANY_DATA"
+      status2: "INVITE_USER"
+      status3: "SELECT_COMPANY_DATA"
+      status4: "UPLOAD_DOCUMENTS"
+      status5: "VERIFY"
     documentTypeIds:
       type0: "CX_FRAME_CONTRACT"
       type1: "COMMERCIAL_REGISTER_EXTRACT"


### PR DESCRIPTION
## Description

This PR includes configuration for new endpoint api/registration/applications/declinedata
Corresponding backend-PR: https://github.com/eclipse-tractusx/portal-backend/pull/385

## Why

new configuration-values are mandatory for startup of registrationservice.

## Issue

N/A

https://github.com/eclipse-tractusx/portal-backend/pull/385

## Checklist

Please delete options that are not relevant.

- [X] I have performed a self-review of my changes
- [X] I have successfully tested my changes
