### PR TITLE
fix(registration-service): fix incorrect applicationDeclineStatusIds

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -293,7 +293,7 @@ backend:
       status0: "CREATED"
       status1: "ADD_COMPANY_DATA"
       status2: "INVITE_USER"
-      status3: "SELECT_COMPANY_DATA"
+      status3: "SELECT_COMPANY_ROLE"
       status4: "UPLOAD_DOCUMENTS"
       status5: "VERIFY"
     documentTypeIds:


### PR DESCRIPTION
## Description

registration config value of applicationDeclineStatusIds have been adjusted

## Why

in PR https://github.com/eclipse-tractusx/portal-cd/pull/136 there was an incorrect value 'SELECT_COMPANY_DATA' set which is not a valid enum value. It has been changed to SELECT_COMPANY_ROLE

## Issue

N/A

https://github.com/eclipse-tractusx/portal-backend/pull/388

## Checklist

Please delete options that are not relevant.

- [X] I have performed a self-review of my changes
- [X] I have successfully tested my changes
