### PR TITLE
fix(services): adjust upload service document type ids

### DIFF
--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -176,7 +176,7 @@ spec:
           value: "{{ .Values.backend.services.uploadServiceDocumentTypeIds.mediaTypeIds1.mediaTypeId2 }}"
         - name: "SERVICES__UPLOADSERVICEDOCUMENTTYPEIDS__2__DOCUMENTTYPEID"
           value: "{{ .Values.backend.services.uploadServiceDocumentTypeIds.documentTypeId2 }}"
-          name: "SERVICES__UPLOADSERVICEDOCUMENTTYPEIDS__2__MEDIATYPES__0"
+        - name: "SERVICES__UPLOADSERVICEDOCUMENTTYPEIDS__2__MEDIATYPES__0"
           value: "{{ .Values.backend.services.uploadServiceDocumentTypeIds.mediaTypeIds2.mediaTypeId0 }}"
         - name: "SERVICES__ITADMINROLES__0__CLIENTID"
           value: "{{ .Values.backend.clients.portal }}"


### PR DESCRIPTION
## Description

Fix the configuration for the upload service document type ids

## Why

missing minus, therefor one configuration was overwritten

## Issue

N/A - Jira Issue: CPLP-3580

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
