### PR TITLE
feat(services): add Conformity_Approval_Service to deletable documents

### DIFF
--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -222,6 +222,8 @@ spec:
           value: "{{ .Values.backend.services.deleteDocumentTypeIds.type0 }}"
         - name: "SERVICES__DELETEDOCUMENTTYPEIDS__1"
           value: "{{ .Values.backend.services.deleteDocumentTypeIds.type1 }}"
+        - name: "SERVICES__DELETEDOCUMENTTYPEIDS__2"
+          value: "{{ .Values.backend.services.deleteDocumentTypeIds.type2 }}"
         - name: "SERVICES__TECHNICALUSERPROFILECLIENT"
           value: "{{ .Values.backend.services.technicalUserProfileClient }}"
         - name: "SERVICES__COMPANYADMINROLES__0__CLIENTID"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -679,6 +679,7 @@ backend:
     deleteDocumentTypeIds:
       type0: "SERVICE_LEADIMAGE"
       type1: "ADDITIONAL_DETAILS"
+      type2: "CONFORMITY_APPROVAL_SERVICES"
     technicalUserProfileClient: "technical_roles_management"
     companyAdminRoles:
       role0: "Company Admin"


### PR DESCRIPTION
## Description

enable deletion of "Conformity_Approval_Service" types.

## Why

DELETE /api/services/ServiceRelease/documents/{documentId}
enable deletion of "Conformity_Approval_Service" types.

## Issue

Link to Github issue.

N/A Ref: CPLP-3652

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
