### PR TITLE
chore(mailing): add sender email configuration

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -251,6 +251,8 @@ spec:
               value: "{{ .Values.backend.mailing.port }}"
             - name: "MAILINGSERVICE__MAIL__SMTPUSER"
               value: "{{ .Values.backend.mailing.user }}"
+            - name: "MAILINGSERVICE__MAIL__SENDEREMAIL"
+              value: "{{ .Values.backend.mailing.senderEmail }}"
             - name: "PROCESSES__LOCKEXPIRYSECONDS"
               value: "{{ .Values.backend.processesworker.processes.lockExpirySeconds }}"
             - name: "PROVISIONING__CENTRALIDENTITYPROVIDER__CONFIG__CLIENTID"

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -305,6 +305,8 @@ spec:
           value: "{{ .Values.backend.mailing.port }}"
         - name: "MAILINGSERVICE__MAIL__SMTPUSER"
           value: "{{ .Values.backend.mailing.user }}"
+        - name: "MAILINGSERVICE__MAIL__SENDEREMAIL"
+          value: "{{ .Values.backend.mailing.senderEmail }}"
         - name: "NETWORK2NETWORK__INITIALROLES__0__CLIENTID"
           value: "{{ .Values.backend.clients.registration }}"
         - name: "NETWORK2NETWORK__INITIALROLES__0__USERROLENAMES__0"

--- a/charts/portal/templates/deployment-backend-appmarketplace.yaml
+++ b/charts/portal/templates/deployment-backend-appmarketplace.yaml
@@ -306,6 +306,8 @@ spec:
           value: "{{ .Values.backend.mailing.port }}"
         - name: "MAILINGSERVICE__MAIL__SMTPUSER"
           value: "{{ .Values.backend.mailing.user }}"
+        - name: "MAILINGSERVICE__MAIL__SENDEREMAIL"
+          value: "{{ .Values.backend.mailing.senderEmail }}"
         - name: "PROVISIONING__CENTRALREALM"
           value: "{{ .Values.backend.provisioning.centralRealm }}"
         - name: "PROVISIONING__CENTRALREALMID"

--- a/charts/portal/templates/deployment-backend-registration.yaml
+++ b/charts/portal/templates/deployment-backend-registration.yaml
@@ -148,6 +148,8 @@ spec:
           value: "{{ .Values.backend.mailing.port }}"
         - name: "MAILINGSERVICE__MAIL__SMTPUSER"
           value: "{{ .Values.backend.mailing.user }}"
+        - name: "MAILINGSERVICE__MAIL__SENDEREMAIL"
+          value: "{{ .Values.backend.mailing.senderEmail }}"
         - name: "PROVISIONING__CENTRALREALM"
           value: "{{ .Values.backend.provisioning.centralRealm }}"
         - name: "PROVISIONING__INVITEDUSERINITIALROLES__0__CLIENTID"

--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -138,6 +138,8 @@ spec:
           value: "{{ .Values.backend.mailing.port }}"
         - name: "MAILINGSERVICE__MAIL__SMTPUSER"
           value: "{{ .Values.backend.mailing.user }}"
+        - name: "MAILINGSERVICE__MAIL__SENDEREMAIL"
+          value: "{{ .Values.backend.mailing.senderEmail }}"
         - name: "PROVISIONING__CENTRALREALM"
           value: "{{ .Values.backend.provisioning.centralRealm }}"
         - name: "PROVISIONING__CENTRALREALMID"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -246,6 +246,8 @@ backend:
     user: "smtp-user"
     # -- Password for the smtp username. Secret-key 'password'.
     password: ""
+    # -- The email which is set as a sender
+    senderEmail: "email@example.org"
   interfaces:
     # -- Secret containing the client-secrets for the connection to custodian, bpdm, sdFactory, clearinghouse, offer provider and onboarding service provider.
     secret: "secret-backend-interfaces"

--- a/consortia/environments/values-beta.yaml
+++ b/consortia/environments/values-beta.yaml
@@ -119,6 +119,7 @@ backend:
     port: "<path:portal/data/mailing#port>"
     user: "<path:portal/data/mailing#user>"
     password: "<path:portal/data/mailing#password>"
+    senderEmail: "Notifications@catena-x.net"
 
   registration:
     logging:

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -119,6 +119,7 @@ backend:
     port: "<path:portal/data/mailing#port>"
     user: "<path:portal/data/mailing#user>"
     password: "<path:portal/data/mailing#password>"
+    senderEmail: "Notifications@catena-x.net"
 
   registration:
     logging:

--- a/consortia/environments/values-int.yaml
+++ b/consortia/environments/values-int.yaml
@@ -119,6 +119,7 @@ backend:
     port: "<path:portal/data/mailing#port>"
     user: "<path:portal/data/mailing#user>"
     password: "<path:portal/data/mailing#password>"
+    senderEmail: "Notifications@catena-x.net"
 
   registration:
     logging:

--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -120,6 +120,7 @@ backend:
     port: "<path:portal/data/mailing#port>"
     user: "<path:portal/data/mailing#user>"
     password: "<path:portal/data/mailing#password>"
+    senderEmail: "Notifications@catena-x.net"
 
   registration:
     logging:

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -119,6 +119,7 @@ backend:
     port: "<path:portal/data/mailing#port>"
     user: "<path:portal/data/mailing#user>"
     password: "<path:portal/data/mailing#password>"
+    senderEmail: "Notifications@catena-x.net"
 
   registration:
     logging:


### PR DESCRIPTION
## Description

Add configuration for the sender email for each specific service

## Why

The portal backend has removed the hardcoded sender email for the mail service, therefor the configuration of the sender email is needed

## Issue

Refs: [#425](https://github.com/eclipse-tractusx/portal-backend/issues/425)

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
