### PR TITLE
chore: add configuration for clientId claim

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -235,6 +235,9 @@ backend:
       authRealm: "master"
       # -- Flag if the api should be used with an leading /auth path
       useAuthTrail: true
+    claims:
+      # -- identifier how to resolve the client_id claim
+      clientId: ""
   mailing:
     # -- Secret containing the passwords for backend.mailing and backend.provisioning.sharedRealm.
     secret: "secret-backend-mailing"

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -113,6 +113,8 @@ backend:
     shared:
       clientId: "<path:portal/data/keycloak#shared-client-id>"
       clientSecret: "<path:portal/data/dev/keycloak#shared-client-secret>"
+    claims:
+      clientId: "clientId"
 
   mailing:
     host: "<path:portal/data/mailing#host>"

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -113,6 +113,8 @@ backend:
     shared:
       clientId: "<path:portal/data/keycloak#shared-client-id>"
       clientSecret: "<path:portal/data/dev/keycloak#shared-client-secret>"
+    claims:
+      clientId: "clientId"
 
   mailing:
     host: "<path:portal/data/mailing#host>"


### PR DESCRIPTION
## Description

Add the clientId claim configuration for dev and rc

## Why

The token contains different clientId claims, for dev and rc it is clientId, for int it is client_id 

## Issue

Refs: [#457](https://github.com/eclipse-tractusx/portal-backend/issues/457)

## Corresponding Backend PR

[#458](https://github.com/eclipse-tractusx/portal-backend/pull/458)

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
