### PR TITLE
fix: add portalPassword to postgresportal for helm upgrade

### DIFF
--- a/charts/localdev/values.yaml
+++ b/charts/localdev/values.yaml
@@ -377,6 +377,7 @@ postgresportal:
     password: ""
     replicationPassword: ""
     portalUser: "portal"
+    portalPassword: ""
     provisioningUser: "provisioning"
     provisioningPassword: ""
   architecture: "replication"


### PR DESCRIPTION
## Description

'portalPassword' was added to localdev values.yaml coordinates 'postgresportal.auth'

## Why

helm upgrade would fail expecting a valid string in .Values.postgresportal.auth.portalPassword

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [X] I have performed a self-review of my changes
- [X] I have successfully tested my changes