### PR TITLE
chore(trg-4-07): enable readOnlyRootFilesystem 

### DIFF
--- a/charts/portal/templates/cronjob-backend-portal-maintenance.yaml
+++ b/charts/portal/templates/cronjob-backend-portal-maintenance.yaml
@@ -35,6 +35,7 @@ spec:
               capabilities:
                 drop:
                 - ALL
+              readOnlyRootFilesystem: true
               runAsNonRoot: true
             image: "{{ .Values.backend.portalmaintenance.image.name }}:{{ .Values.backend.portalmaintenance.image.portalmaintenancetag | default .Chart.AppVersion }}"
             imagePullPolicy: "Always"

--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -36,6 +36,7 @@ spec:
               capabilities:
                 drop:
                 - ALL
+              readOnlyRootFilesystem: true
               runAsNonRoot: true
             image: "{{ .Values.backend.processesworker.image.name }}:{{ .Values.backend.processesworker.image.processesworkertag | default .Chart.AppVersion }}"
             imagePullPolicy: "Always"

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -40,6 +40,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         image: "{{ .Values.backend.administration.image.name }}:{{ .Values.backend.administration.image.administrationservicetag | default .Chart.AppVersion }}"
         imagePullPolicy: "Always"

--- a/charts/portal/templates/deployment-backend-appmarketplace.yaml
+++ b/charts/portal/templates/deployment-backend-appmarketplace.yaml
@@ -40,6 +40,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         image: "{{ .Values.backend.appmarketplace.image.name }}:{{ .Values.backend.appmarketplace.image.appmarketplaceservicetag | default .Chart.AppVersion }}"
         imagePullPolicy: "Always"

--- a/charts/portal/templates/deployment-backend-notification.yaml
+++ b/charts/portal/templates/deployment-backend-notification.yaml
@@ -40,6 +40,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         image: "{{ .Values.backend.notification.image.name }}:{{ .Values.backend.notification.image.notificationservicetag | default .Chart.AppVersion }}"
         imagePullPolicy: "Always"

--- a/charts/portal/templates/deployment-backend-registration.yaml
+++ b/charts/portal/templates/deployment-backend-registration.yaml
@@ -40,6 +40,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         image: "{{ .Values.backend.registration.image.name }}:{{ .Values.backend.registration.image.registrationservicetag | default .Chart.AppVersion }}"
         imagePullPolicy: "Always"

--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -40,6 +40,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         image: "{{ .Values.backend.services.image.name }}:{{ .Values.backend.services.image.servicesservicetag | default .Chart.AppVersion }}"
         imagePullPolicy: "Always"

--- a/charts/portal/templates/deployment-frontend-assets.yaml
+++ b/charts/portal/templates/deployment-frontend-assets.yaml
@@ -71,6 +71,12 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.frontend.assets.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      volumes:
+      - emptyDir: {}
+        name: tmp
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/portal/templates/deployment-frontend-assets.yaml
+++ b/charts/portal/templates/deployment-frontend-assets.yaml
@@ -40,6 +40,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         image: {{ .Values.frontend.assets.image.name }}:{{ .Values.frontend.assets.image.assetstag | default .Chart.AppVersion }}
         imagePullPolicy: "Always"

--- a/charts/portal/templates/deployment-frontend-portal.yaml
+++ b/charts/portal/templates/deployment-frontend-portal.yaml
@@ -40,6 +40,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         image: {{ .Values.frontend.portal.image.name }}:{{ .Values.frontend.portal.image.portaltag | default .Chart.AppVersion }}
         imagePullPolicy: "Always"

--- a/charts/portal/templates/deployment-frontend-portal.yaml
+++ b/charts/portal/templates/deployment-frontend-portal.yaml
@@ -84,6 +84,12 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.frontend.portal.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      volumes:
+      - emptyDir: {}
+        name: tmp
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/portal/templates/deployment-frontend-registration.yaml
+++ b/charts/portal/templates/deployment-frontend-registration.yaml
@@ -78,6 +78,12 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.frontend.registration.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      volumes:
+      - emptyDir: {}
+        name: tmp
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/portal/templates/deployment-frontend-registration.yaml
+++ b/charts/portal/templates/deployment-frontend-registration.yaml
@@ -40,6 +40,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         image: {{ .Values.frontend.registration.image.name }}:{{ .Values.frontend.registration.image.registrationtag | default .Chart.AppVersion }}
         imagePullPolicy: "Always"

--- a/charts/portal/templates/job-backend-portal-migrations.yaml
+++ b/charts/portal/templates/job-backend-portal-migrations.yaml
@@ -38,6 +38,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         image: "{{ .Values.backend.portalmigrations.image.name }}:{{ .Values.backend.portalmigrations.image.portalmigrationstag | default .Chart.AppVersion }}"
         imagePullPolicy: "Always"

--- a/charts/portal/templates/job-backend-provisioning-migrations.yaml
+++ b/charts/portal/templates/job-backend-provisioning-migrations.yaml
@@ -38,6 +38,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         image: "{{ .Values.backend.provisioningmigrations.image.name }}:{{ .Values.backend.provisioningmigrations.image.provisioningmigrationstag | default .Chart.AppVersion }}"
         imagePullPolicy: "Always"


### PR DESCRIPTION
## Description

- enable readOnlyRootFilesystem in containers
- mount tmp frontend deployment, required by nginx base image but also by 00-inject-dynamic-env.sh (executed via docker entrypoint) for [portal](https://github.com/eclipse-tractusx/portal-frontend/pull/471) and [registration app](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/110)

## Why

https://eclipse-tractusx.github.io/docs/release/trg-0/trg-4-07

## Issue

https://github.com/eclipse-tractusx/portal-cd/issues/159

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have commented my code, particularly in hard-to-understand areas
