### PR TITLE
feat(certificate): add company certificate media type id

### DIFF
--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -177,6 +177,7 @@ dependencies:
 | backend.administration.healthChecks | object | `{"startup":{"tags":[{"name":"HEALTHCHECKS__0__TAGS__1","value":"portaldb"},{"name":"HEALTHCHECKS__0__TAGS__2","value":"provisioningdb"}]}}` | Keycloak Healthcheck to be enabled for startupProbe; once the centralidp Keycloak instance is available, enable healthcheck by uncommenting. |
 | backend.administration.companyData.useCaseParticipationMediaTypes.type0 | string | `"PDF"` |  |
 | backend.administration.companyData.ssiCertificateMediaTypes.type0 | string | `"PDF"` |  |
+| backend.administration.companyData.companyCertificateMediaTypes.type0 | string | `"PDF"` |  |
 | backend.administration.connectors.validCertificationContentTypes.type0 | string | `"application/x-pem-file"` |  |
 | backend.administration.connectors.validCertificationContentTypes.type1 | string | `"application/x-x509-ca-cert"` |  |
 | backend.administration.connectors.validCertificationContentTypes.type2 | string | `"application/pkix-cert"` |  |

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -179,6 +179,8 @@ spec:
           value: "{{ .Values.backend.administration.companyData.useCaseParticipationMediaTypes.type0 }}"
         - name: "COMPANYDATA__SSICERTIFICATEMEDIATYPES__0"
           value: "{{ .Values.backend.administration.companyData.ssiCertificateMediaTypes.type0 }}"
+        - name: "COMPANYDATA__COMPANYCERTIFICATEMEDIATYPES__0"
+          value: "{{ .Values.backend.administration.companyData.companyCertificateMediaTypes.type0 }}"
         - name: "CONNECTORS__VALIDCERTIFICATIONCONTENTTYPES__0"
           value: "{{ .Values.backend.administration.connectors.validCertificationContentTypes.type0 }}"
         - name: "CONNECTORS__VALIDCERTIFICATIONCONTENTTYPES__1"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -340,7 +340,7 @@ backend:
         type0: "PDF"
       ssiCertificateMediaTypes:
         type0: "PDF"
-      comapnyCertificateMediaTypes:
+      companyCertificateMediaTypes:
         type0: "PDF"
     connectors:
       validCertificationContentTypes:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -340,6 +340,8 @@ backend:
         type0: "PDF"
       ssiCertificateMediaTypes:
         type0: "PDF"
+      comapnyCertificateMediaTypes:
+        type0: "PDF"
     connectors:
       validCertificationContentTypes:
         type0: "application/x-pem-file"


### PR DESCRIPTION

## Description

Adding required secret key for company certificate post endpoint

## Why

For accessing specific company certificate as per it company userId, status and types.

## Issue

#468

Link to pull request from other repository.

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
