### PR TITLE
fix(keycloak): add shared client secret config

### DIFF
--- a/charts/portal/templates/secret-backend-keycloak.yaml
+++ b/charts/portal/templates/secret-backend-keycloak.yaml
@@ -39,5 +39,6 @@ stringData:
   # if secret doesn't exist, use provided value from values file or generate a random one
   central-db-password: {{ .Values.backend.keycloak.central.dbConnection.password | default ( randAlphaNum 32 ) | quote }}
   central-client-secret: {{ .Values.backend.keycloak.central.clientSecret | default ( randAlphaNum 32 ) | quote }}
+  shared-client-secret: {{ .Values.backend.keycloak.shared.clientSecret | default ( randAlphaNum 32 ) | quote }}
   shareddelete-client-secret: {{ .Values.backend.keycloak.shareddelete.clientSecret | default ( randAlphaNum 32 ) | quote }}
 {{ end }}


### PR DESCRIPTION
## Description

Add shared-client-secret to secret generation if not existing

## Why

If not existing the setup fails due to a missing config value

## Issue

N/A

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
