### PR TITLE
fix(registration): set registration path with /

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -297,7 +297,7 @@ backend:
         #   value: "keycloak"
         - name: "HEALTHCHECKS__0__TAGS__1"
           value: "portaldb"
-    portalRegistrationPath: "/registration"
+    portalRegistrationPath: "/registration/"
     keycloakClientId: "Cl1-CX-Registration"
     applicationStatusIds:
       status0: "SUBMITTED"


### PR DESCRIPTION
## Description

Adjust the registration url to /registration/

## Why

Currently the link is set to /registration which the ingress redirects to the frontend not to the registration app

## Issue

N/A

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
