### PR TITLE
chore: always set mvc routing basepath

### DIFF
--- a/charts/portal/templates/deployment-backend-appmarketplace.yaml
+++ b/charts/portal/templates/deployment-backend-appmarketplace.yaml
@@ -64,8 +64,6 @@ spec:
           value: "Server={{ .Values.postgresql.fullnameOverride }}-primary;Database={{ .Values.postgresql.auth.database }};Port={{ .Values.postgresql.auth.port }};User Id={{ .Values.postgresql.auth.provisioningUser }};Password=$(PROVISIONING_PASSWORD);Ssl Mode={{ .Values.backend.dbConnection.sslMode }};"
         {{- end }}
         {{- if not .Values.postgresql.enabled }}
-        - name: "MVC_ROUTING_BASEPATH"
-          value: "{{ .Values.backend.appmarketplace.basePath }}"
         - name: "PORTAL_PASSWORD"
           valueFrom:
             secretKeyRef:
@@ -294,6 +292,8 @@ spec:
           value: "{{ .Values.sharedidpAddress }}"
         - name: "KEYCLOAK__SHARED__USEAUTHTRAIL"
           value: "{{ .Values.backend.keycloak.shared.useAuthTrail }}"
+        - name: "MVC_ROUTING_BASEPATH"
+          value: "{{ .Values.backend.appmarketplace.basePath }}"
         - name: "SERILOG__MINIMUMLEVEL__Default"
           value: "{{ .Values.backend.appmarketplace.logging.default }}"
         - name: "SERILOG__MINIMUMLEVEL__OVERRIDE__Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Service"

--- a/charts/portal/templates/deployment-backend-notification.yaml
+++ b/charts/portal/templates/deployment-backend-notification.yaml
@@ -59,8 +59,6 @@ spec:
           value: "Server={{ .Values.postgresql.fullnameOverride }}-primary;Database={{ .Values.postgresql.auth.database }};Port={{ .Values.postgresql.auth.port }};User Id={{ .Values.postgresql.auth.portalUser }};Password=$(PORTAL_PASSWORD);Ssl Mode={{ .Values.backend.dbConnection.sslMode }};"
         {{- end }}
         {{- if not .Values.postgresql.enabled }}
-        - name: "MVC_ROUTING_BASEPATH"
-          value: "{{ .Values.backend.notification.basePath }}"
         - name: "PORTAL_PASSWORD"
           valueFrom:
             secretKeyRef:
@@ -134,6 +132,8 @@ spec:
           value: "{{ .Values.sharedidpAddress }}"
         - name: "KEYCLOAK__SHARED__USEAUTHTRAIL"
           value: "{{ .Values.backend.keycloak.shared.useAuthTrail }}"
+        - name: "MVC_ROUTING_BASEPATH"
+          value: "{{ .Values.backend.notification.basePath }}"
         - name: "SERILOG__MINIMUMLEVEL__Default"
           value: "{{ .Values.backend.notification.logging.default }}"
         - name: "SWAGGERENABLED"

--- a/charts/portal/templates/deployment-backend-registration.yaml
+++ b/charts/portal/templates/deployment-backend-registration.yaml
@@ -66,8 +66,6 @@ spec:
           value: "Server={{ .Values.postgresql.fullnameOverride }}-primary;Database={{ .Values.postgresql.auth.database }};Port={{ .Values.postgresql.auth.port }};User Id={{ .Values.postgresql.auth.portalUser }};Password=$(PORTAL_PASSWORD);Ssl Mode={{ .Values.backend.dbConnection.sslMode }};"
         {{- end }}
         {{- if not .Values.postgresql.enabled }}
-        - name: "MVC_ROUTING_BASEPATH"
-          value: "{{ .Values.backend.registration.basePath }}"
         - name: "PORTAL_PASSWORD"
           valueFrom:
             secretKeyRef:
@@ -153,6 +151,8 @@ spec:
           value: "{{ .Values.backend.mailing.user }}"
         - name: "MAILINGSERVICE__MAIL__SENDEREMAIL"
           value: "{{ .Values.backend.mailing.senderEmail }}"
+        - name: "MVC_ROUTING_BASEPATH"
+          value: "{{ .Values.backend.registration.basePath }}"
         - name: "PROVISIONING__CENTRALREALM"
           value: "{{ .Values.backend.provisioning.centralRealm }}"
         - name: "PROVISIONING__INVITEDUSERINITIALROLES__0__CLIENTID"

--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -64,8 +64,6 @@ spec:
           value: "Server={{ .Values.postgresql.fullnameOverride }}-primary;Database={{ .Values.postgresql.auth.database }};Port={{ .Values.postgresql.auth.port }};User Id={{ .Values.postgresql.auth.provisioningUser }};Password=$(PROVISIONING_PASSWORD);Ssl Mode={{ .Values.backend.dbConnection.sslMode }};"
         {{- end }}
         {{- if not .Values.postgresql.enabled }}
-        - name: "MVC_ROUTING_BASEPATH"
-          value: "{{ .Values.backend.services.basePath }}"
         - name: "PORTAL_PASSWORD"
           valueFrom:
             secretKeyRef:
@@ -143,6 +141,8 @@ spec:
           value: "{{ .Values.backend.mailing.user }}"
         - name: "MAILINGSERVICE__MAIL__SENDEREMAIL"
           value: "{{ .Values.backend.mailing.senderEmail }}"
+        - name: "MVC_ROUTING_BASEPATH"
+          value: "{{ .Values.backend.services.basePath }}"
         - name: "PROVISIONING__CENTRALREALM"
           value: "{{ .Values.backend.provisioning.centralRealm }}"
         - name: "PROVISIONING__CENTRALREALMID"


### PR DESCRIPTION
## Description

Move the mvc routing base path configuration to a non if statement, that it's always set correctly.

## Why

The sync in argo fails due to the missing configuration

## Issue

Refs: [494](https://github.com/eclipse-tractusx/portal-backend/pull/494)

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
