### PR TITLE
fix: mount tmp directory to enable file upload

### DIFF
--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -47,6 +47,8 @@ spec:
         env:
         - name: DOTNET_ENVIRONMENT
           value: "{{ .Values.backend.dotnetEnvironment }}"
+        - name: TMPDIR
+          value: "/mnt/tmp"
         {{- if .Values.postgresql.enabled }}
         - name: "PORTAL_PASSWORD"
           valueFrom:
@@ -428,6 +430,12 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.backend.administration.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /mnt/tmp
+          name: tmp
+      volumes:
+      - emptyDir: {}
+        name: tmp
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/portal/templates/deployment-backend-appmarketplace.yaml
+++ b/charts/portal/templates/deployment-backend-appmarketplace.yaml
@@ -47,6 +47,8 @@ spec:
         env:
         - name: DOTNET_ENVIRONMENT
           value: "{{ .Values.backend.dotnetEnvironment }}"
+        - name: TMPDIR
+          value: "/mnt/tmp"
         {{- if .Values.postgresql.enabled }}
         - name: "PORTAL_PASSWORD"
           valueFrom:
@@ -353,6 +355,12 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.backend.appmarketplace.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /mnt/tmp
+          name: tmp
+      volumes:
+      - emptyDir: {}
+        name: tmp
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/portal/templates/deployment-backend-registration.yaml
+++ b/charts/portal/templates/deployment-backend-registration.yaml
@@ -47,6 +47,8 @@ spec:
         env:
         - name: DOTNET_ENVIRONMENT
           value: "{{ .Values.backend.dotnetEnvironment }}"
+        - name: TMPDIR
+          value: "/mnt/tmp"
         {{- if .Values.postgresql.enabled }}
         - name: "PORTAL_PASSWORD"
           valueFrom:
@@ -195,7 +197,6 @@ spec:
           value: "{{ .Values.backend.registration.registrationDocumentTypeIds.type0 }}"
         - name: "REGISTRATION__SUBMITDOCUMENTTYPEIDS__0"
           value: "{{ .Values.backend.registration.submitDocumentTypeIds.type0 }}"
-
         ports:
         - name: http
           containerPort: {{ .Values.portContainer }}
@@ -232,6 +233,12 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.backend.registration.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /mnt/tmp
+          name: tmp
+      volumes:
+      - emptyDir: {}
+        name: tmp
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -47,6 +47,8 @@ spec:
         env:
         - name: DOTNET_ENVIRONMENT
           value: "{{ .Values.backend.dotnetEnvironment }}"
+        - name: TMPDIR
+          value: "/mnt/tmp"
         {{- if .Values.postgresql.enabled }}
         - name: "PORTAL_PASSWORD"
           valueFrom:
@@ -275,6 +277,12 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.backend.services.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /mnt/tmp
+          name: tmp
+      volumes:
+      - emptyDir: {}
+        name: tmp
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Description

fix: mount tmp directory to enable file upload with readOnlyRootFilesystem

## Why

https://github.com/eclipse-tractusx/portal-cd/issues/183

## Checklist

- [x] I have performed a self-review of my changes
- [ ] I have successfully tested my changes
